### PR TITLE
bug fix: announce route hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ const lightningOpts = {
   cert: ..., // base64 encoded string of tls.cert
   macaroon: ..., // base64 encoded string of macaroon
   network: ..., // mainnet / testnet / regtest
-  implementation: ..., // 'c-lightning' or 'lnd'
+  host: ..., // <host>:<port>
   oninvoice: function (invoice) {
     // handle incoming invoice, e.g. display as QR
   }

--- a/lnd.js
+++ b/lnd.js
@@ -158,7 +158,8 @@ module.exports = class Payment {
 
     this.Lightning.addInvoice({
       memo: filter,
-      value: amount
+      value: amount,
+      private: true
     }, function (err, res) {
       if (err) return cb(err)
 
@@ -185,7 +186,6 @@ module.exports = class Payment {
       return cb(new Error(payment.payment_error))
     })
   }
-
 
   earnings () {
     const earnings = {}


### PR DESCRIPTION
for mainnet transactions, receiver must announce private channels to allow sender to route. `private` flag added when requesting invoice solves this. 