### PR TITLE
Recover invoice stream after temporary LND disconnect

### DIFF
--- a/lnd.js
+++ b/lnd.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const LndGrpc = require('lnd-grpc')
 const lndconnect = require('lndconnect')
 const clerk = require('payment-tracker')
@@ -209,6 +208,7 @@ module.exports = class Payment extends EventEmitter {
     if (!cb) cb = noop
 
     const call = this.Lightning.sendPayment()
+
     call.write({
       payment_request: paymentRequest.request
     })

--- a/lnd.js
+++ b/lnd.js
@@ -35,8 +35,6 @@ module.exports = class Payment extends EventEmitter {
       await this.unlock(password)
     })
 
-    this.client.on('error', console.log)
-
     this.client.once('disconnected', () => {
       this.client = new LndGrpc(opts)
       this.initialized = null


### PR DESCRIPTION
If LND node disconnects temporarily and reconnects before the dazaar process crashes, the invoice stream is no longer live and the seller is not aware of newly paid invoices.

This PR fixes this behaviour by continuously attempting to reestablish the invoice stream after it has ended.